### PR TITLE
Use alternative method to find battery

### DIFF
--- a/custom_components/redback/redbacklib.py
+++ b/custom_components/redback/redbacklib.py
@@ -91,7 +91,7 @@ class RedbackInverter:
         # a "BatteryCount" of zero. This is a less elegant way to assess if a battery
         # is present. If Redback resolve that bug in their API, this can be removed.
         energy_data = await self.getEnergyData()
-        return energy_data.get("BatteryPowerNegativeIsChargingkW", None) is not None
+        return energy_data.get("BatterySoCInstantaneous0to1", None) is not None
 
         # inverter_info = await self.getInverterInfo()
         # return inverter_info.get("BatteryCount", 0) > 0

--- a/custom_components/redback/redbacklib.py
+++ b/custom_components/redback/redbacklib.py
@@ -86,8 +86,15 @@ class RedbackInverter:
     async def hasBattery(self):
         # Note: private API doesn't have "BatteryCount", need examples without
         # battery so the hasBattery() method can be updated to suit
-        inverter_info = await self.getInverterInfo()
-        return inverter_info.get("BatteryCount", 0) > 0
+
+        # Note: In some as yet unidentified circumstances the inverter info returns 
+        # a "BatteryCount" of zero. This is a less elegant way to assess if a battery
+        # is present. If Redback resolve that bug in their API, this can be removed.
+        energy_data = await self.getEnergyData()
+        return energy_data.get("BatteryPowerNegativeIsChargingkW", None) is not None
+
+        # inverter_info = await self.getInverterInfo()
+        # return inverter_info.get("BatteryCount", 0) > 0
 
     async def _apiGetBearerToken(self):
         """Returns an active OAuth2 bearer token for use with public API methods"""


### PR DESCRIPTION
This uses an alternative method to check if there is a battery by checking if there is a battery SoC data item in the dynamic energy data, in an attempt to work around #18 

I have also contacted Redback in the hope that the API can be fixed instead, and this pull request would then be moot.

I'm not clear on how this would interact with the "private" API, or how many people this change might benefit.