### PR TITLE
Measure cumulative energy by maintaining running total

### DIFF
--- a/custom_components/redback/sensor.py
+++ b/custom_components/redback/sensor.py
@@ -487,7 +487,7 @@ class RedbackEnergySensor(RedbackEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.ENERGY
 
     def __init__(self, coordinator: RedbackDataUpdateCoordinator, details) -> None:        
-        super().__init__(coordinator)
+        super().__init__(coordinator, details)
         self._attr_native_value = 0
         self._attr_last_reset = datetime.now()
         self._last_update = datetime.now()

--- a/custom_components/redback/sensor.py
+++ b/custom_components/redback/sensor.py
@@ -511,8 +511,9 @@ class RedbackEnergySensor(RedbackEntity, SensorEntity):
         time_delta = sample_time - self._last_update    # Assume sample value is representative of the time since last update
         self._last_update = sample_time
         hours = time_delta.total_seconds()/3600
-        self._attr_native_value = measurement * hours  # multiply watts by hours to get Wh
-        if self.convertkW: self._attr_native_value /= 1000 # convert from Wh to kWh
+        measurement = measurement * hours  # multiply watts by hours to get Wh        
+        if self.convertkW: self.measurement /= 1000 # convert from Wh to kWh
+        self._attr_native_value += measurement 
         self.async_write_ha_state()
 
 class RedbackEnergyMeter(RedbackEntity, SensorEntity):


### PR DESCRIPTION
Instead of declaring a reset for each sample, total them, scaling them for the time between samples.